### PR TITLE
Disable unredirect when showing the overlay

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -101,8 +101,10 @@ class GameBar extends PanelMenu.Button {
         if (this._overlay.visible) {
             // If visible, hide the overlay
             this._overlay.hide();
+            Meta.enable_unredirect_for_display(global.display);
         } else {
             // If not visible, show the overlay and update the clock and volume controls
+            Meta.disable_unredirect_for_display(global.display);
             this._overlay.show();
             this._clock._updateClock();
             this._soundControls.updateVolumeControls();

--- a/extension.js
+++ b/extension.js
@@ -101,10 +101,27 @@ class GameBar extends PanelMenu.Button {
         if (this._overlay.visible) {
             // If visible, hide the overlay
             this._overlay.hide();
-            Meta.enable_unredirect_for_display(global.display);
+
+            // Enable unredirect back when the overlay is closed.
+            try {
+                // Enable unredirect for GNOME 47 and below.
+                Meta.enable_unredirect_for_display(global.display);
+            } catch (exception) {
+                // Enable unredirect for GNOME 48 and above.
+                global.compositor.enable_unredirect();
+            }
+            
         } else {
+            // Disable unredirect before showing the overlay to prevent fullscreen windows from obstructing the overlay.
+            try {
+                // Disable unredirect for GNOME 47 and below.
+                Meta.disable_unredirect_for_display(global.display);
+            } catch (exception) {
+                // Enable unredirect for GNOME 48 and above.
+                global.compositor.disable_unredirect();
+            }
+
             // If not visible, show the overlay and update the clock and volume controls
-            Meta.disable_unredirect_for_display(global.display);
             this._overlay.show();
             this._clock._updateClock();
             this._soundControls.updateVolumeControls();

--- a/extension.js
+++ b/extension.js
@@ -7,6 +7,7 @@ import Meta from 'gi://Meta';
 import Shell from 'gi://Shell';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import * as PanelMenu from 'resource:///org/gnome/shell/ui/panelMenu.js';
+import * as Config from 'resource:///org/gnome/shell/misc/config.js';
 import {Extension, gettext as _} from 'resource:///org/gnome/shell/extensions/extension.js';
 import { set_padding_setting } from './utils.js';
 
@@ -18,6 +19,11 @@ import {SoundControls} from './addons/soundControls.js';
 //TODO:: weather addon
 //TODO:: battery addon
 //TODO:: brightness addon
+
+function isGnome48OrNewer() {
+    let version = Config.PACKAGE_VERSION.split('.').map(Number);
+    return version[0] >= 48;
+}
 
 const GameBar = GObject.registerClass(
 class GameBar extends PanelMenu.Button {
@@ -103,22 +109,22 @@ class GameBar extends PanelMenu.Button {
             this._overlay.hide();
 
             // Enable unredirect back when the overlay is closed.
-            try {
-                // Enable unredirect for GNOME 47 and below.
-                Meta.enable_unredirect_for_display(global.display);
-            } catch (exception) {
+            if (isGnome48OrNewer()){
                 // Enable unredirect for GNOME 48 and above.
                 global.compositor.enable_unredirect();
+            }else{
+                // Enable unredirect for GNOME 47 and below.
+                Meta.enable_unredirect_for_display(global.display);
             }
-            
+
         } else {
             // Disable unredirect before showing the overlay to prevent fullscreen windows from obstructing the overlay.
-            try {
-                // Disable unredirect for GNOME 47 and below.
-                Meta.disable_unredirect_for_display(global.display);
-            } catch (exception) {
+            if (isGnome48OrNewer()){
                 // Enable unredirect for GNOME 48 and above.
                 global.compositor.disable_unredirect();
+            }else{
+                // Disable unredirect for GNOME 47 and below.
+                Meta.disable_unredirect_for_display(global.display);
             }
 
             // If not visible, show the overlay and update the clock and volume controls


### PR DESCRIPTION
This should fix the overlay visibility when a fullscreen window is on top. Unredirect seems to be some kind of fullscreen optimization in GNOME, while looking through the gnome-shell code, i found that when OSD is shown, it [disables this unredirect thing](https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/osdWindow.js?ref_type=heads#L95)  

- [x] Test on GNOME 47 (Wayland)
- [x] Test on GNOME 47 (X11)
- [x] Test on GNOME 48 (Wayland)
- [x] Test on GNOME 48 (X11)
- [x] Test with a few XWayland fullscreen games
- [x] Test with a few Wayland native fullscreen games

Closes https://github.com/dekotale/GameBar-Overlay/issues/12