### PR TITLE
Grab key focus & Close overlay with ESC key

### DIFF
--- a/addons/closeButton.js
+++ b/addons/closeButton.js
@@ -4,7 +4,7 @@ import GLib from 'gi://GLib';
 import { getPositionStyle } from '../utils.js';
 
 export class CloseButton {
-    constructor(overlay, primaryMonitor) {
+    constructor(overlay, primaryMonitor, toggleOverlay) {
         this._overlay = overlay;
         this._primaryMonitor = primaryMonitor;
         this._toggleOverlay = toggleOverlay;
@@ -44,7 +44,7 @@ export class CloseButton {
         this._overlay.connect('button-release-event', (actor, event) => {
           if (this._emptyAreaClose) {
             // Check if the overlay itself was clicked
-            if (actor === this._overlay) {
+            if (this._overlay.visible && actor === this._overlay) {
                 this._toggleOverlay();
             }
           }

--- a/addons/closeButton.js
+++ b/addons/closeButton.js
@@ -7,6 +7,7 @@ export class CloseButton {
     constructor(overlay, primaryMonitor) {
         this._overlay = overlay;
         this._primaryMonitor = primaryMonitor;
+        this._toggleOverlay = toggleOverlay;
         this._closeButton = null;
         this._addonContainer = null;
         this._widthChangeId = null;
@@ -32,7 +33,7 @@ export class CloseButton {
 
         // Hide the overlay when the close button is clicked
         this._closeButton.connect('clicked', () => {
-            this._overlay.hide();
+            this._toggleOverlay();
         });
 
         this._addonContainer.add_child(this._closeButton)
@@ -44,7 +45,7 @@ export class CloseButton {
           if (this._emptyAreaClose) {
             // Check if the overlay itself was clicked
             if (actor === this._overlay) {
-                this._overlay.hide();
+                this._toggleOverlay();
             }
           }
         });

--- a/extension.js
+++ b/extension.js
@@ -80,7 +80,7 @@ class GameBar extends PanelMenu.Button {
 
         // Create instances of addons and pass the overlay widget and the primary monitor
         this._clock = new Clock(this._overlay, primaryMonitor); // Clock addon
-        this._closeButton = new CloseButton(this._overlay, primaryMonitor); // Close button addon
+        this._closeButton = new CloseButton(this._overlay, primaryMonitor, this._toggleOverlay.bind(this)); // Close button addon
         this._soundControls = new SoundControls(this._overlay, primaryMonitor); // Sound controls addon
 
         // Add the overlay widget to the global stage to affect the input region.

--- a/extension.js
+++ b/extension.js
@@ -24,6 +24,7 @@ function isGnome48OrNewer() {
     let version = Config.PACKAGE_VERSION.split('.').map(Number);
     return version[0] >= 48;
 }
+const MUTTER_SCHEMA = 'org.gnome.mutter';
 
 const GameBar = GObject.registerClass(
 class GameBar extends PanelMenu.Button {
@@ -48,6 +49,9 @@ class GameBar extends PanelMenu.Button {
 
         // Connect the 'button-press-event' signal of the GameBar panel button to the _toggleOverlay method
         this.connect('button-press-event', this._toggleOverlay.bind(this));
+
+        this._mutterSettings = new Gio.Settings({'schema': MUTTER_SCHEMA});
+        this._ignoreOverlayKeyChangedEvent = false;
     }
 
     /**
@@ -104,6 +108,37 @@ class GameBar extends PanelMenu.Button {
 
     }
 
+    _overrideOverlayKey() {
+        if (!this._overlay.visible){
+            return;
+        }
+
+        this.defaultOverlayKeyID = GObject.signal_handler_find(global.display, { signalId: 'overlay-key' });
+
+        if (!this.defaultOverlayKeyID) {
+            return;
+        }
+
+        GObject.signal_handler_block(global.display, this.defaultOverlayKeyID);
+
+        Main.wm.allowKeybinding('overlay-key', Shell.ActionMode.ALL);
+    }
+
+    _restoreOverlayKey() {
+        if (this.defaultOverlayKeyID) {
+            GObject.signal_handler_unblock(global.display, this.defaultOverlayKeyID);
+            this.defaultOverlayKeyID = null;
+        }
+
+        if (this._overlayKeyId) {
+            global.display.disconnect(this._overlayKeyId);
+            this._overlayKeyId = null;
+        }
+        
+        Main.wm.allowKeybinding('overlay-key', Shell.ActionMode.NORMAL | Shell.ActionMode.OVERVIEW);
+    }
+
+
     /**
      * Toggles the visibility of the overlay widget.
      * If the overlay is visible, it is hidden.
@@ -126,6 +161,9 @@ class GameBar extends PanelMenu.Button {
                 Meta.enable_unredirect_for_display(global.display);
             }
 
+            //When this overlay is not visible, restore the default GNOME overlay toggle key
+            this._restoreOverlayKey();
+
         } else {
             // Disable unredirect before showing the overlay to prevent fullscreen windows from obstructing the overlay.
             if (isGnome48OrNewer()){
@@ -143,6 +181,9 @@ class GameBar extends PanelMenu.Button {
 
             // Grab key focus
             global.stage.set_key_focus(this._overlay);
+
+            //Override the GNOME-default overlay toggle key when this overlay is visible
+            this._overrideOverlayKey();
         }
     }
 

--- a/extension.js
+++ b/extension.js
@@ -105,6 +105,8 @@ class GameBar extends PanelMenu.Button {
     _toggleOverlay() {
         // Check if the overlay is visible
         if (this._overlay.visible) {
+            // Unset key focus
+            global.stage.set_key_focus(null);
             // If visible, hide the overlay
             this._overlay.hide();
 
@@ -131,6 +133,9 @@ class GameBar extends PanelMenu.Button {
             this._overlay.show();
             this._clock._updateClock();
             this._soundControls.updateVolumeControls();
+
+            // Grab key focus
+            global.stage.set_key_focus(this._overlay);
         }
     }
 

--- a/extension.js
+++ b/extension.js
@@ -87,6 +87,13 @@ class GameBar extends PanelMenu.Button {
             //TODO:: fix bug: when change to a diferent resolution monitor, the size wont update properly
             this._updateOverlayGeometry(Main.layoutManager.primaryMonitor);
         });
+
+        // Connect to 'key-press-event' signal to close the overlay when ESC key is clicked
+        this._overlay.connect('key-press-event', (actor, event) => {
+            if (this._overlay.visible && event.get_key_symbol() === Clutter.KEY_Escape) {
+                this._toggleOverlay(); 
+            }
+        });
     }
 
     //Update overlay geometry


### PR DESCRIPTION
Changes:
* Grab key focus
* Close overlay with ESC key

Works with programs/games but it seems impossible to cancel certain compositor shortcuts (Super key, alt+tab.....)  but anyway this shouldn't be a big issue.
Closes https://github.com/dekotale/GameBar-Overlay/issues/14