### PR TITLE
Fix clock font width (tabular numbers)

### DIFF
--- a/stylesheet.css
+++ b/stylesheet.css
@@ -14,8 +14,7 @@
     border-radius: 15px; 
     padding: 5px 20px;
     font-weight: 500;
-    /**TODO:: Fix The width of the clock addon's container slightly 
-    changes size when the text displaying the time changes.**/
+    font-feature-settings: "tnum";
 }
 
 /*Close button styles*/


### PR DESCRIPTION
# Before:
![before](https://github.com/user-attachments/assets/fa0553f3-7b24-4de0-9f08-3f2f7d4f2fc5)
# After:
![after](https://github.com/user-attachments/assets/27c71741-9151-4e51-b84b-58a8aa8ce425)
Noticable visual changes:
* No more width changes (it's also slightly wider)
* Better ":" spacing
* Some numbers look different now, but that's how they look in the GNOME's clock in the top panel.  

Tested on Adwaita Sans, need to check other fonts maybe?