### PR TITLE
Add GNOME 49 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -6,9 +6,10 @@
   "shell-version": [
     "46",
     "47",
-    "48"
+    "48",
+    "49"
   ],
   "url": "https://github.com/dekotale/GameBar-Overlay",
   "uuid": "gamebar-overlay@dekotale.github.io",
-  "version": 12
+  "version": 13
 }


### PR DESCRIPTION
no issues in gnome 49.alpha

![imagen](https://github.com/user-attachments/assets/a7a5c9b2-13a1-4267-abd7-cc125187ecae)
