### PR TITLE
Update README.md with optional dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Just clone the repo into `~/.local/share/gnome-shell/extensions/gamebar-overlay@
 Installing these packages is optional, but they will provide additional functionality to this extension.  
 
 - `libgtop` - required for the System Monitor addon.
-- `hwdata` - needed to read your hardware model.
+- `hwdata` - needed to read your GPU name.
 
 ## Usage
 


### PR DESCRIPTION
Mention the optional dependencies in the README.   
The lack of `libgtop` is alredy handled in the code, i will handle missing `hwdata`  in another PR.