### PR TITLE
Handle missing hwdata

### DIFF
--- a/prefs.js
+++ b/prefs.js
@@ -5,7 +5,7 @@ import Gdk from 'gi://Gdk';
 import GLib from 'gi://GLib';
 
 import {ExtensionPreferences, gettext as _} from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
-import { listGpus, getGpuModel } from './utils.js';
+import { listGpus, getGpuModel, readFile } from './utils.js';
 
 export default class Preferences extends ExtensionPreferences {
     fillPreferencesWindow(window) {
@@ -483,5 +483,19 @@ export default class Preferences extends ExtensionPreferences {
             settings.set_string('gpu-device', selectedDevice);
         });
         gpuGroup.add(gpuRow);
+
+        // Display a warning if hwdata is missing.
+        if (readFile("/usr/share/hwdata/pci.ids") === null) {
+            const hwdataRow = new Adw.ActionRow({
+                title: _("'hwdata' not installed: can't get GPU name!")
+            });
+
+            const box = new Gtk.Box({ orientation: Gtk.Orientation.HORIZONTAL, spacing: 10 });
+            const icon = new Gtk.Image({ iconName: "dialog-warning-symbolic" });
+            icon.set_margin_end(10);
+            box.append(icon);
+            hwdataRow.add_prefix(box)
+            gpuGroup.add(hwdataRow);
+        }
     }
 }

--- a/utils.js
+++ b/utils.js
@@ -143,6 +143,11 @@ const getGpuModel = (drm_id) => {
     const expectedVendorId = readFile(basePath + "/vendor").replace("0x", "");
     const expectedDeviceId = readFile(basePath + "/device").replace("0x", "");
     const hwdata = readFile("/usr/share/hwdata/pci.ids");
+
+    // Some distributions (for example Debian) don't install hwdata by default.
+    if (hwdata === null) {
+        return "Unknown (" + getGpuDriver(drm_id) + ")";
+    }
     
     let foundVendor = false;
     for (const line of hwdata.split("\n")) {


### PR DESCRIPTION
Add a null check for the hwdata `pci.ids` file, which may be missing if the package is not installed.  
Closes #26 
![Zrzut ekranu z 2025-06-13 16-02-23](https://github.com/user-attachments/assets/368f4a23-4c8a-41bf-874e-8ec76af609cf)